### PR TITLE
refactor(entity): externalize predefined difficulty tables to JSON

### DIFF
--- a/internal/entity/data/predefine_tables.json
+++ b/internal/entity/data/predefine_tables.json
@@ -1,0 +1,197 @@
+{
+  "schemeNames": ["Raw", "Zris", "616sb"],
+  "headers": [
+    {
+      "name": "Stardust",
+      "symbol": "ξ",
+      "category": "Starter",
+      "tagColor": "#E5F4D3",
+      "tagTextColor": "#2B410D",
+      "headerUrls": {
+        "Raw": "https://mqppppp.neocities.org/StardustTable.html"
+      }
+    },
+    {
+      "name": "Starlight",
+      "symbol": "sr",
+      "category": "Starter",
+      "tagColor": "#E8EDFF",
+      "tagTextColor": "#121D52",
+      "headerUrls": {
+        "Raw": "https://djkuroakari.github.io/starlighttable.html"
+      }
+    },
+    {
+      "name": "通常難易度表",
+      "symbol": "☆",
+      "category": "Starter",
+      "tagColor": "#EDF7FD",
+      "tagTextColor": "#0F5F8A",
+      "headerUrls": {
+        "Raw": "http://www.ribbit.xyz/bms/tables/normal.html",
+        "Zris": "http://zris.work/bmstable/normal/normal_header.json",
+        "616sb": "https://bms.alvorna.com/tables/ff4cb9d4c6f14f68a895798143a2a7b9/header.json"
+      }
+    },
+    {
+      "name": "NEW GENERATION 通常難易度表",
+      "symbol": "▽",
+      "category": "Starter",
+      "tagColor": "#FFFAEB",
+      "tagTextColor": "#946D18",
+      "headerUrls": {
+        "Raw": "http://rattoto10.jounin.jp/table.html",
+        "Zris": "http://zris.work/bmstable/normal2/header.json",
+        "616sb": "https://bms.alvorna.com/tables/1c7c8c5d80338a5835f8221ca8d1bc47/header.json"
+      }
+    },
+    {
+      "name": "Satellite",
+      "symbol": "sl",
+      "category": "Insane",
+      "tagColor": "#B6EAD2",
+      "tagTextColor": "#0A4D2F",
+      "headerUrls": {
+        "Raw": "https://stellabms.xyz/sl/table.html",
+        "Zris": "http://zris.work/bmstable/satellite/header.json",
+        "616sb": "https://bms.alvorna.com/tables/adceda62af0cac6fdba049c0ced12479/header.json"
+      }
+    },
+    {
+      "name": "発狂BMS難易度表",
+      "symbol": "★",
+      "category": "Insane",
+      "tagColor": "#A3D8F5",
+      "tagTextColor": "#0F5F8A",
+      "headerUrls": {
+        "Raw": "http://www.ribbit.xyz/bms/tables/insane.html",
+        "Zris": "http://zris.work/bmstable/insane/insane_header.json",
+        "616sb": "https://bms.alvorna.com/tables/ea159b8f57a768682957735baf332e04/header.json"
+      }
+    },
+    {
+      "name": "NEW GENERATION 発狂難易度表",
+      "symbol": "▼",
+      "category": "Insane",
+      "tagColor": "#FFECB9",
+      "tagTextColor": "#946D18",
+      "headerUrls": {
+        "Raw": "http://rattoto10.jounin.jp/table_insane.html",
+        "Zris": "http://zris.work/bmstable/insane2/insane_header.json",
+        "616sb": "https://bms.alvorna.com/tables/5f5d17d84528e331316304128063a515/header.json"
+      }
+    },
+    {
+      "name": "第三期Overjoy",
+      "symbol": "★★",
+      "category": "Overjoy",
+      "tagColor": "#DDBDF2",
+      "tagTextColor": "#5C2989",
+      "headerUrls": {
+        "Raw": "http://rattoto10.jounin.jp/table_overjoy.html",
+        "Zris": "http://zris.work/bmstable/overjoy/header.json",
+        "616sb": "https://bms.alvorna.com/tables/6096431ac74339abf61389cd60a5586e/header.json"
+      }
+    },
+    {
+      "name": "Stella",
+      "symbol": "st",
+      "category": "Overjoy",
+      "tagColor": "#FFB5A8",
+      "tagTextColor": "#331510",
+      "headerUrls": {
+        "Raw": "https://stellabms.xyz/st/table.html",
+        "Zris": "http://zris.work/bmstable/stella/header.json",
+        "616sb": "https://bms.alvorna.com/tables/be86d1e944f4003491b970f4797d6c9a/header.json"
+      }
+    },
+    {
+      "name": "δ難易度表",
+      "symbol": "δ",
+      "category": "DP",
+      "tagColor": "#EDF7FD",
+      "tagTextColor": "#0F5F8A",
+      "headerUrls": {
+        "Raw": "https://deltabms.yaruki0.net/table/dpdelta",
+        "Zris": "http://zris.work/bmstable/dp_normal/dpn_header.json"
+      }
+    },
+    {
+      "name": "発狂DP難易度表",
+      "symbol": "★",
+      "category": "DP",
+      "tagColor": "#A3D8F5",
+      "tagTextColor": "#0F5F8A",
+      "headerUrls": {
+        "Raw": "https://deltabms.yaruki0.net/table/dpinsane",
+        "Zris": "http://zris.work/bmstable/dp_insane/dpi_header.json"
+      }
+    },
+    {
+      "name": "DP Overjoy",
+      "symbol": "★★",
+      "category": "DP",
+      "tagColor": "#DDBDF2",
+      "tagTextColor": "#5C2989",
+      "headerUrls": {
+        "Raw": "http://ereter.net/dpoverjoy",
+        "Zris": "http://zris.work/bmstable/dp_overjoy/header.json"
+      }
+    },
+    {
+      "name": "DP Satellite",
+      "symbol": "DPsl",
+      "category": "DP",
+      "tagColor": "#B6EAD2",
+      "tagTextColor": "#0A4D2F",
+      "headerUrls": {
+        "Raw": "https://stellabms.xyz/dp/table.html",
+        "Zris": "http://zris.work/bmstable/dp_satellite/header.json"
+      }
+    },
+    {
+      "name": "DP Stella",
+      "symbol": "DPst",
+      "category": "DP",
+      "tagColor": "#FFB5A8",
+      "tagTextColor": "#331510",
+      "headerUrls": {
+        "Raw": "https://stellabms.xyz/dpst/table.html",
+        "Zris": "http://zris.work/bmstable/dp_stella/header.json"
+      }
+    },
+    {
+      "name": "PMSデータベース(Lv1~45)",
+      "symbol": "PLv",
+      "category": "PMS",
+      "tagColor": "#EDF7FD",
+      "tagTextColor": "#0F5F8A",
+      "headerUrls": {
+        "Raw": "http://pmsdifficulty.xxxxxxxx.jp/PMSdifficulty.html",
+        "Zris": "http://zris.work/bmstable/pms_normal/pmsdatabase_header.json"
+      }
+    },
+    {
+      "name": "発狂PMSデータベース(lv46～)",
+      "symbol": "P●",
+      "category": "PMS",
+      "tagColor": "#A3D8F5",
+      "tagTextColor": "#0F5F8A",
+      "headerUrls": {
+        "Raw": "https://pmsdifficulty.xxxxxxxx.jp/insane_PMSdifficulty.html",
+        "Zris": "http://zris.work/bmstable/pms_insane/insane_pmsdatabase_header.json"
+      }
+    },
+    {
+      "name": "発狂PMS難易度表",
+      "symbol": "●",
+      "category": "PMS",
+      "tagColor": "#FFECB9",
+      "tagTextColor": "#946D18",
+      "headerUrls": {
+        "Raw": "https://pmsdifficulty.xxxxxxxx.jp/_pastoral_home.html",
+        "Zris": "http://zris.work/bmstable/pms_upper/header.json"
+      }
+    }
+  ]
+}

--- a/internal/entity/diffTableHeader.go
+++ b/internal/entity/diffTableHeader.go
@@ -1,6 +1,8 @@
 package entity
 
 import (
+	_ "embed"
+	"encoding/json"
 	"strings"
 
 	"github.com/Catizard/bmstable"
@@ -51,8 +53,6 @@ type PredefineTableHeader struct {
 	TagColor     string
 	TagTextColor string
 	Category     string
-
-	headerUrls map[string]string // Internal use, to simplify the init step
 }
 
 // One predefined header scheme is basically an array of headers
@@ -60,240 +60,52 @@ type PredefineTableHeader struct {
 type PredefineTableScheme struct {
 	Headers []PredefineTableHeader
 	Name    string
-	//SelectedCategory []string
 }
 
-var PredefineTableSchemeNames []string = []string{
-	"Raw",
-	"Zris",
-	"616sb",
+//go:embed data/predefine_tables.json
+var predefineTablesJSON []byte
+
+type predefineTableJSON struct {
+	SchemeNames []string                 `json:"schemeNames"`
+	Headers     []predefineTableJSONEntry `json:"headers"`
 }
 
-var PredefineTableSchemes map[string]PredefineTableScheme = make(map[string]PredefineTableScheme)
+type predefineTableJSONEntry struct {
+	Name         string            `json:"name"`
+	Symbol       string            `json:"symbol"`
+	Category     string            `json:"category"`
+	TagColor     string            `json:"tagColor"`
+	TagTextColor string            `json:"tagTextColor"`
+	HeaderUrls   map[string]string `json:"headerUrls"`
+}
+
+var PredefineTableSchemeNames []string
+var PredefineTableSchemes map[string]PredefineTableScheme
 
 func init() {
-	urlJoinedHeaders := make([]PredefineTableHeader, 0)
-	// NOTE: The element in headerUrls' order must follow the order of PredefineTableSchemeNames
-	// Starter category
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "Stardust",
-		Symbol:       "ξ",
-		Category:     "Starter",
-		TagColor:     "#E5F4D3",
-		TagTextColor: "#2B410D",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "https://mqppppp.neocities.org/StardustTable.html",
-			/* No zris mirror */
-			/* No 616sb mirror */
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "Starlight",
-		Symbol:       "sr",
-		Category:     "Starter",
-		TagColor:     "#E8EDFF",
-		TagTextColor: "#121D52",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "https://djkuroakari.github.io/starlighttable.html",
-			/* No zris mirror */
-			/* No 616sb mirror */
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "通常難易度表",
-		Symbol:       "☆",
-		Category:     "Starter",
-		TagColor:     "#EDF7FD",
-		TagTextColor: "#0F5F8A",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "http://www.ribbit.xyz/bms/tables/normal.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/normal/normal_header.json",
-			PredefineTableSchemeNames[2]: "https://bms.alvorna.com/tables/ff4cb9d4c6f14f68a895798143a2a7b9/header.json",
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "NEW GENERATION 通常難易度表",
-		Symbol:       "▽",
-		Category:     "Starter",
-		TagColor:     "#FFFAEB",
-		TagTextColor: "#946D18",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "http://rattoto10.jounin.jp/table.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/normal2/header.json",
-			PredefineTableSchemeNames[2]: "https://bms.alvorna.com/tables/1c7c8c5d80338a5835f8221ca8d1bc47/header.json",
-		},
-	})
-	// Insane category
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "Satellite",
-		Symbol:       "sl",
-		Category:     "Insane",
-		TagColor:     "#B6EAD2",
-		TagTextColor: "#0A4D2F",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "https://stellabms.xyz/sl/table.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/satellite/header.json",
-			PredefineTableSchemeNames[2]: "https://bms.alvorna.com/tables/adceda62af0cac6fdba049c0ced12479/header.json",
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "発狂BMS難易度表",
-		Symbol:       "★",
-		Category:     "Insane",
-		TagColor:     "#A3D8F5",
-		TagTextColor: "#0F5F8A",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "http://www.ribbit.xyz/bms/tables/insane.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/insane/insane_header.json",
-			PredefineTableSchemeNames[2]: "https://bms.alvorna.com/tables/ea159b8f57a768682957735baf332e04/header.json",
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "NEW GENERATION 発狂難易度表",
-		Symbol:       "▼",
-		Category:     "Insane",
-		TagColor:     "#FFECB9",
-		TagTextColor: "#946D18",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "http://rattoto10.jounin.jp/table_insane.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/insane2/insane_header.json",
-			PredefineTableSchemeNames[2]: "https://bms.alvorna.com/tables/5f5d17d84528e331316304128063a515/header.json",
-		},
-	})
-	// Overjoy category
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "第三期Overjoy",
-		Symbol:       "★★",
-		Category:     "Overjoy",
-		TagColor:     "#DDBDF2",
-		TagTextColor: "#5C2989",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "http://rattoto10.jounin.jp/table_overjoy.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/overjoy/header.json",
-			PredefineTableSchemeNames[2]: "https://bms.alvorna.com/tables/6096431ac74339abf61389cd60a5586e/header.json",
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "Stella",
-		Symbol:       "st",
-		Category:     "Overjoy",
-		TagColor:     "#FFB5A8",
-		TagTextColor: "#331510",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "https://stellabms.xyz/st/table.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/stella/header.json",
-			PredefineTableSchemeNames[2]: "https://bms.alvorna.com/tables/be86d1e944f4003491b970f4797d6c9a/header.json",
-		},
-	})
-	// DP category
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "δ難易度表",
-		Symbol:       "δ",
-		Category:     "DP",
-		TagColor:     "#EDF7FD",
-		TagTextColor: "#0F5F8A",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "https://deltabms.yaruki0.net/table/dpdelta",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/dp_normal/dpn_header.json",
-			/* No 616sb mirror */
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "発狂DP難易度表",
-		Symbol:       "★",
-		Category:     "DP",
-		TagColor:     "#A3D8F5",
-		TagTextColor: "#0F5F8A",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "https://deltabms.yaruki0.net/table/dpinsane",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/dp_insane/dpi_header.json",
-			/* No 616sb mirror */
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "DP Overjoy",
-		Symbol:       "★★",
-		Category:     "DP",
-		TagColor:     "#DDBDF2",
-		TagTextColor: "#5C2989",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "http://ereter.net/dpoverjoy",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/dp_overjoy/header.json",
-			/* No 616sb mirror */
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "DP Satellite",
-		Symbol:       "DPsl",
-		Category:     "DP",
-		TagColor:     "#B6EAD2",
-		TagTextColor: "#0A4D2F",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "https://stellabms.xyz/dp/table.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/dp_satellite/header.json",
-			/* No 616sb mirror */
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "DP Stella",
-		Symbol:       "DPst",
-		Category:     "DP",
-		TagColor:     "#FFB5A8",
-		TagTextColor: "#331510",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "https://stellabms.xyz/dpst/table.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/dp_stella/header.json",
-			/* No 616sb mirror */
-		},
-	})
-	// PMS category
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "PMSデータベース(Lv1~45)",
-		Symbol:       "PLv",
-		Category:     "PMS",
-		TagColor:     "#EDF7FD",
-		TagTextColor: "#0F5F8A",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "http://pmsdifficulty.xxxxxxxx.jp/PMSdifficulty.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/pms_normal/pmsdatabase_header.json",
-			/* No 616sb mirror */
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "発狂PMSデータベース(lv46～)",
-		Symbol:       "P●",
-		Category:     "PMS",
-		TagColor:     "#A3D8F5",
-		TagTextColor: "#0F5F8A",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "https://pmsdifficulty.xxxxxxxx.jp/insane_PMSdifficulty.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/pms_insane/insane_pmsdatabase_header.json",
-			/* No 616sb mirror */
-		},
-	})
-	urlJoinedHeaders = append(urlJoinedHeaders, PredefineTableHeader{
-		Name:         "発狂PMS難易度表",
-		Symbol:       "●",
-		Category:     "PMS",
-		TagColor:     "#FFECB9",
-		TagTextColor: "#946D18",
-		headerUrls: map[string]string{
-			PredefineTableSchemeNames[0]: "https://pmsdifficulty.xxxxxxxx.jp/_pastoral_home.html",
-			PredefineTableSchemeNames[1]: "http://zris.work/bmstable/pms_upper/header.json",
-			/* No 616sb mirror */
-		},
-	})
+	var jsonData predefineTableJSON
+	if err := json.Unmarshal(predefineTablesJSON, &jsonData); err != nil {
+		panic("failed to parse predefine_tables.json: " + err.Error())
+	}
+
+	PredefineTableSchemeNames = jsonData.SchemeNames
+	PredefineTableSchemes = make(map[string]PredefineTableScheme, len(PredefineTableSchemeNames))
 
 	for _, schemeName := range PredefineTableSchemeNames {
-		headers := make([]PredefineTableHeader, 0)
-		for _, header := range urlJoinedHeaders {
-			shallow := header
-			// push down
-			shallow.HeaderUrl = header.headerUrls["Raw"]
-			if url, ok := header.headerUrls[schemeName]; ok {
-				shallow.HeaderUrl = url
+		headers := make([]PredefineTableHeader, 0, len(jsonData.Headers))
+		for _, h := range jsonData.Headers {
+			header := PredefineTableHeader{
+				Name:         h.Name,
+				Symbol:       h.Symbol,
+				Category:     h.Category,
+				TagColor:     h.TagColor,
+				TagTextColor: h.TagTextColor,
+				HeaderUrl:    h.HeaderUrls["Raw"],
 			}
-			headers = append(headers, shallow)
+			if url, ok := h.HeaderUrls[schemeName]; ok {
+				header.HeaderUrl = url
+			}
+			headers = append(headers, header)
 		}
 		PredefineTableSchemes[schemeName] = PredefineTableScheme{
 			Name:    schemeName,


### PR DESCRIPTION
## Summary

- Move 22 hardcoded predefine table header definitions from `init()` in `diffTableHeader.go` into an external JSON file.
- The JSON is embedded at compile time via `//go:embed`, preserving the same runtime behavior.
- Removed the `headerUrls` internal field from `PredefineTableHeader` (only used in the old init logic).

## Changes

1. **`internal/entity/data/predefine_tables.json`** (new) — all predefined table headers with their per-scheme URLs, colors, and categories.
2. **`internal/entity/diffTableHeader.go`** — replaced the 220-line hardcoded `init()` block with JSON deserialization, removed the `headerUrls` field.

## Why

- Configuration data separated from code — easier to review, maintain, and extend.
- Reduces `diffTableHeader.go` by ~200 lines of data boilerplate.
- Adding/modifying a predefined table is now a data change, not a code change.

## Verification

- `go build ./...` passes.
- All 43 diff-table related tests pass.
- Behavior is identical: default URL = "Raw" scheme, overridden per scheme match, same as before.
